### PR TITLE
adding plot numticks option to `plot(m,'b')` (#165)

### DIFF
--- a/Examples/Example_10_Multiscale_Smoother.m
+++ b/Examples/Example_10_Multiscale_Smoother.m
@@ -22,8 +22,13 @@ mshopts = mshopts.build;
 
 m = mshopts.grd; 
 
+% Plotting mesh without cleaning
 plot(m)
+title('Mesh without cleaning')
 
+% clean
 m = m.clean;
 
+% Plotting mesh with cleaning
 plot(m)
+title('Mesh after cleaning')

--- a/Examples/Example_11_Remeshing_Patches.m
+++ b/Examples/Example_11_Remeshing_Patches.m
@@ -69,4 +69,6 @@ m_new = plus(subdomain_new, m_w_hole, 'match');
 % the new mesh
 ind = nearest_neighbor_map(m, m_new);
 m_new.b = m.b(ind); 
-plot(m_new,'bmesh'); hold on; plot(poly{1}(1:end-1,1),poly{1}(1:end-1,2),'r-','linewi',3);
+% Plot the bathy on the mesh with hole polygon in red
+plot(m_new,'type','bmesh'); hold on; 
+plot(poly{1}(1:end-1,1),poly{1}(1:end-1,2),'r-','linewi',3);

--- a/Examples/Example_1_NZ.m
+++ b/Examples/Example_1_NZ.m
@@ -30,11 +30,11 @@ mshopts = mshopts.build;
 % Get out the msh class and put on nodestrings
 m = mshopts.grd;
 m = make_bc(m,'auto',gdat,'distance'); % make the boundary conditions
-plot(m,'bd',1);
+plot(m,'type','bd');
 % if you want to write into fort.14...
 % write(m,'South_Island_NZ');
 
 %% STEP 6: Example of plotting a subdomain with bcs
 bbox_s =  [172   176;
            -42   -39];
-plot(m,'bd',1,[],bbox_s)
+plot(m,'type','bd','subset',bbox_s)

--- a/Examples/Example_2_NY.m
+++ b/Examples/Example_2_NY.m
@@ -33,5 +33,6 @@ m = mshopts.grd;
 m = interp(m,gdat,'mindepth',1); % interpolate bathy to the mesh with minimum depth of 1 m
 m = make_bc(m,'auto',gdat,'depth',5);  % make the nodestring boundary conditions 
                                  % with min depth of 5 m on open boundary
-plot(m,'bd'); plot(m,'blog');    % plot triangulation, and bathy on log scale
+plot(m,'type','bd');      % plot triangulation with bcs  
+plot(m,'type','blog');    % plot bathy on log scale
 write(m,'NY_HR');                % write to ADCIRC compliant ascii file

--- a/Examples/Example_3_ECGC.m
+++ b/Examples/Example_3_ECGC.m
@@ -59,6 +59,6 @@ mshopts = mshopts.build;
 m = mshopts.grd; % get out the msh object
 m = interp(m,{gdat1 gdat2},'mindepth',1); % interpolate bathy to the mesh with minimum depth of 1 m
 m = make_bc(m,'auto',gdat1);               % make the nodestring boundary conditions
-plot(m,'bd',1); % plot on native projection with nodestrings
-plot(m,'b',1); % plot bathy on native projection
+plot(m,'type','bd');  % plot mesh on native projection with boundary conditions
+plot(m,'type','b');   % plot bathy on native projection
 save('ECGC_w_NYHR.mat','m'); write(m,'ECGC_w_NYHR');

--- a/Examples/Example_4_PRVI.m
+++ b/Examples/Example_4_PRVI.m
@@ -81,9 +81,9 @@ m = interp(m,gdat,'mindepth',1); % interpolate bathy to the mesh with minimum de
 m = make_bc(m,'auto',gdat{1}); % make the nodestring boundary conditions
 
 %% Plot and save the msh class object/write to fort.14
-plot(m,'bd'); % plot triangulation with nodestrings
-plot(m,'b'); % plot the bathy
-plot(m,'reso',1,[],[],[10, 0 10e3]) % plot the resolution
+plot(m,'type','bd'); % plot triangulation with boundary conditions
+plot(m,'type','b');  % plot the bathy
+plot(m,'type','reso','colormap',[10 0 10e3]) % plot the resolution
 % Save as a msh class
 save('PRVI_msh.mat','m');
 % Write an ADCIRC fort.14 compliant file to disk.

--- a/Examples/Example_5_JBAY.m
+++ b/Examples/Example_5_JBAY.m
@@ -41,5 +41,6 @@ m = interp(m,gdat,'nan','fill','mindepth',1); % interpolate bathy to the
                 % mesh with fill nan option to make sure corners get values
 m = make_bc(m,'auto',gdat,'depth',5); % make the nodestring boundary conditions
                            % with depth cutoff for open boundary set to 5 m
-plot(m,'bd'); plot(m,'blog'); % plot triangulation and bathy
+plot(m,'type','bd'); % plot triangulation with boundary conditions
+plot(m,'type','blog'); % plot bathy on log scale
 save('JBAY_HR.mat','m')

--- a/Examples/Example_5b_JBAY_w_weirs.m
+++ b/Examples/Example_5b_JBAY_w_weirs.m
@@ -72,7 +72,7 @@ m = make_bc(m,'weirs',gdat,1,[weirs.crestheight]);  % add bcs for the weirs
 %% STEP 6: interpolate bathy and plot and save the mesh
 m = interp(m,gdat,'nan','fill','mindepth',1); % interpolate bathy to the
                 % mesh with fill nan option to make sure corners get values
-plot(m,'bd'); % visualize your boundaries
-plot(m,'bmesh'); % plot triangulation and bathy
-caxis([-10 0]) ;
+plot(m,'type','bd');   % plot triangulation with boundary conditions
+plot(m,'type','blog'); % plot bathy on log scale
+% saving mesh
 save('JBAY_HR.mat','m')

--- a/Examples/Example_6_GBAY.m
+++ b/Examples/Example_6_GBAY.m
@@ -37,5 +37,7 @@ mshopts = mshopts.build;
 m = mshopts.grd;
 m = interp(m,gdat,'mindepth',1,'nan','fill'); % interpolate bathy to the mesh
 m = make_bc(m,'auto',gdat); % make the nodestring boundary conditions
-plot(m,'bd'); plot(m,'blog'); % plot triangulation and bathy
+% Plotting and writing 
+plot(m,'type','bmesh'); % plot bathy on the mesh
+plot(m,'type','bdnotri','holdon',1);  % plot the boundary conditions on top of the bathy mesh
 write(m,'HoustonShipChannel');

--- a/Examples/Example_6b_GBAY_w_floodplain.m
+++ b/Examples/Example_6b_GBAY_w_floodplain.m
@@ -65,10 +65,10 @@ mshopts = mshopts.build;
 
 m = mshopts.grd ;
 
-% plot resolution
-plot(m,'resomesh',1,[],[],[10 0 1e3])
+% plot resolution on the mesh
+plot(m,'type','resomesh','colormap',[10 0 1e3])
 
 %interpolate bathy using special constraining technique for overland and
 %underwater
 m = interpFP(m,gdat,muw,gdatuw);
-plot(m,'bmesh')
+plot(m,'type','bmesh') % plot the bathy on the mesh

--- a/Examples/Example_7_Global.m
+++ b/Examples/Example_7_Global.m
@@ -40,7 +40,7 @@ mshopts = mshopts.build;
 %% STEP 5: Match points and edges across boundary
 m = mshopts.grd; % get out the msh object 
 
-% Plotting the triangulation on Robinson
-plot(m,'tri',1,'Robinson');
+% Plotting the triangulation on Robinson projection
+plot(m,'type','tri','proj','Robinson');
 save([outname '.mat'],'m'); 
 %write(m,outname);

--- a/Examples/Example_8_AK.m
+++ b/Examples/Example_8_AK.m
@@ -41,6 +41,6 @@ mshopts = mshopts.build;
 %% STEP 5: Extract the msh class, make the boundary conditions and plot
 m = mshopts.grd; % Get out the msh class
 m = make_bc(m,'auto',gdat,'distance'); % make the boundary conditions
-plot(m,'bd');
+plot(m,'type','bd'); % plot the boundary conditions on the mesh
 
 m = interp(m,'GEBCO_2014_2D.nc','mindepth',5);

--- a/Examples/Example_9_TBAY.m
+++ b/Examples/Example_9_TBAY.m
@@ -59,7 +59,7 @@ m_min = m_min.build;
 m_min = m_min.grd;
 
 %% Plot the two meshes
-plot(m_nomin,'tri')
+plot(m_nomin)
 title('Without Enforcing Minimum of all Edgefunctions')
-plot(m_min,'tri')
+plot(m_min)
 title('Enforcing Minimum of all Edgefunctions')

--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ Table of contents
 <!--te-->
 
 ## IMPORTANT NOTE:
-This is the default and recommended `PROJECTION` branch. Please use it unless you otherwise require legacy (`MASTER` branch) or the absolute newest features (`DEV` branch). 
+This is the default and recommended `PROJECTION` branch. Please use it unless you otherwise require legacy (`MASTER` branch) or the absolute newest features (`DEV` branch).
 
-OceanMesh2D is a set of user-friendly MATLAB functions to generate two-dimensional (2D) unstructured meshes for coastal ocean circulation problems. These meshes are based on a variety of feature driven geometric and bathymetric mesh size functions, which are generated according to user-defined parameters. Mesh generation is achieved through a force-balance algorithm combined with a number of topological improvement strategies aimed at improving the worst case triangle quality. The software embeds the mesh generation process into an object-orientated framework that contains pre- and post-processing workflows, which makes mesh generation flexible, reproducible, and script-able. 
+OceanMesh2D is a set of user-friendly MATLAB functions to generate two-dimensional (2D) unstructured meshes for coastal ocean circulation problems. These meshes are based on a variety of feature driven geometric and bathymetric mesh size functions, which are generated according to user-defined parameters. Mesh generation is achieved through a force-balance algorithm combined with a number of topological improvement strategies aimed at improving the worst case triangle quality. The software embeds the mesh generation process into an object-orientated framework that contains pre- and post-processing workflows, which makes mesh generation flexible, reproducible, and script-able.
 
 Getting help
 ==============
 
 Besides posting [issues](https://github.com/CHLNDDEV/OceanMesh2D/issues) with the code on Github, you can also ask questions via our Slack channel [here](https://join.slack.com/t/oceanmesh2d/shared_invite/zt-igvr8rvo-OctG9t0QEYNyyvVr55ynUQ).
 
-Otherwise please reach out to either Dr. William Pringle (wpringle@anl.gov) or Dr. Keith Roberts (krober@usp.br) with questions or concerns or feel free to start an Issue in the issues tab above. 
+Otherwise please reach out to either Dr. William Pringle (wpringle@anl.gov) or Dr. Keith Roberts (krober@usp.br) with questions or concerns or feel free to start an Issue in the issues tab above.
 
 
 Contributing
@@ -67,22 +67,22 @@ PLEASE READ THE USER GUIDE!
 A recent pdf of the user guide is located in this branch. For a continually updated version click [here](https://www.overleaf.com/read/hsqjhvtbkgvj#/54715995/) (wait for compilation and then click download PDF)
 
 Download the data for the following examples [here](https://drive.google.com/open?id=1LeQJFKaVCM2K59pKO9jDcB02yjTmJPmL)
- 
+
 in addition to [here](http://www.soest.hawaii.edu/pwessel/gshhg/gshhg-shp-2.3.7.zip) for the GSHHG ESRI shapefile and here: "ftp://topex.ucsd.edu/pub/srtm15_plus/SRTM15+V2.1.nc" for the latest SRTM15_PLUS global topobathy DEM.
 ```
-Featured in  ┌╼ Examples/Example_1_NZ.m   %<- A simple mesh around South Island New Zealand that uses GSHHS shoreline. 
-user guide   ├── Examples/Example_2_NY.m   %<- A high-resolution mesh around the New York/Manhattan area that uses a DEM created from LiDAR data.  
+Featured in  ┌╼ Examples/Example_1_NZ.m   %<- A simple mesh around South Island New Zealand that uses GSHHS shoreline.
+user guide   ├── Examples/Example_2_NY.m   %<- A high-resolution mesh around the New York/Manhattan area that uses a DEM created from LiDAR data.
              └── Examples/Example_3_ECGC.m %<- Builds a mesh for the western North Atlantic with a local high-resolution nest around New York
 Featured in         ┌╼ Examples/Example_4_PRVI.m %<- Builds a mesh for the western North Atlantic with three high-resolution nests around Peurto Rico and US Virgin Islands
 Geoscientific Model ├── Examples/Example_5_JBAY.m %<- An extremely high-fidelity (15-m) mesh from LiDAR data around Jamaica Bay with CFL-limiting.
-Development paper[1]└── Examples/Example_6_GBAY.m %<- An example of the polyline/thalweg mesh size function along the Houston Ship Channel. 
+Development paper[1]└── Examples/Example_6_GBAY.m %<- An example of the polyline/thalweg mesh size function along the Houston Ship Channel.
 
 ```
 
 Testing
 ==========
 
-All pull requests are tested with Jenkins on a local host. However, to ensure the software is fully functional on your system it's encouraged to run the tests in Tests/ yourself. 
+All pull requests are tested with Jenkins on a local host. However, to ensure the software is fully functional on your system it's encouraged to run the tests in Tests/ yourself.
 
 
 
@@ -92,23 +92,23 @@ References!
 If you make use of `OceanMesh2D` please include a reference to [1], and to any of [2]-[5] if pertinent ([latex .bib file](https://github.com/CHLNDDEV/OceanMesh2D/tree/Projection/UserGuide/OceanMesh2D_library.bib)). We would also appreciate using our [logo](https://github.com/CHLNDDEV/OceanMesh2D/tree/Projection/imgs) in a presentation featuring `OceanMesh2D`.
 ```
 
-[1] - Roberts, K. J., Pringle, W. J., and Westerink, J. J., 2019. 
-      OceanMesh2D 1.0: MATLAB-based software for two-dimensional unstructured mesh generation in coastal ocean modeling, 
+[1] - Roberts, K. J., Pringle, W. J., and Westerink, J. J., 2019.
+      OceanMesh2D 1.0: MATLAB-based software for two-dimensional unstructured mesh generation in coastal ocean modeling,
       Geoscientific Model Development, 12, 1847-1868. https://doi.org/10.5194/gmd-12-1847-2019.
-[2] - Roberts, K. J., Pringle, W. J, 2018. 
+[2] - Roberts, K. J., Pringle, W. J, 2018.
       OceanMesh2D: User guide - Precise distance-based two-dimensional automated mesh generation toolbox intended for coastal
-      ocean/shallow water. https://doi.org/10.13140/RG.2.2.21840.61446/2.     
+      ocean/shallow water. https://doi.org/10.13140/RG.2.2.21840.61446/2.
 [3] - Roberts, Keith J. Unstructured Mesh Generation and Dynamic Load Balancing for Coastal Ocean Hydrodynamic Simulation, 2019.
       PhD Thesis, University of Notre Dame. https://curate.nd.edu/show/4q77fr0022c.
-[4] - Roberts, Keith J., Pringle W.J., Westerink J. J. Contreras, M.T., Wirasaet, D., 2019. 
-      On the automatic and a priori design of unstructured mesh resolution for coastal ocean circulation models, 
+[4] - Roberts, Keith J., Pringle W.J., Westerink J. J. Contreras, M.T., Wirasaet, D., 2019.
+      On the automatic and a priori design of unstructured mesh resolution for coastal ocean circulation models,
       Ocean Modelling, 144, 101509. https://doi.org/10.1016/j.ocemod.2019.101509.
 [5] - Pringle, W. J., Wirasaet, D., Roberts, K. J., and Westerink, J. J., 2020.
-      Global Storm Tide Modeling with ADCIRC v55: Unstructured Mesh Design and Performance, 
+      Global Storm Tide Modeling with ADCIRC v55: Unstructured Mesh Design and Performance,
       Geoscientific Model Development Discussions. https://doi.org/10.5194/gmd-2020-123.
-      
+
 ```
-In addition, best practice when using software in a scientific publication is to cite the permanent doi corresponding to the version used (e.g., for reproducibility). All our releases are archived at the following `Zenodo` repository doi [link](https://doi.org/10.5281/zenodo.1341384). 
+In addition, best practice when using software in a scientific publication is to cite the permanent doi corresponding to the version used (e.g., for reproducibility). All our releases are archived at the following `Zenodo` repository doi [link](https://doi.org/10.5281/zenodo.1341384).
 ```
 Authors (202X). CHLNDDEV/OceanMesh2D: OceanMesh2D VX.X. Zenodo. https://doi.org/10.5281/zenodo.1341384
 ```
@@ -117,7 +117,7 @@ Please fill in the version (VX.X), author list and year corresponding to the ver
 ## `DISCLAIMER: `
 The boundary of the meshing domain must be a polygon (first point equals the last and non-self intersecting) but it does not need to be simplified. Read the user guide for more information about the inputs.
 
-GALLERY: 
+GALLERY:
 =========
 * These images can be made by running the [examples](https://github.com/CHLNDDEV/OceanMesh2D/tree/Projection/Examples)
 <p align="center">
@@ -133,21 +133,25 @@ Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
-### Unreleased 
+### Unreleased
+
+## Changed
+- `msh.plot()` overhaul. All options specified via kwarg.
+
 ## Fixed
 - Boundary labeling fix
 
 ### [3.3.0] - 2020-12-21
 ## Fixed
-- Users without mapping toolbox could not read in shapefiles because of a bug that 
+- Users without mapping toolbox could not read in shapefiles because of a bug that
   made them required to have a 3d shapefiles.
-- plotting `gdat` with no shoreline. 
+- plotting `gdat` with no shoreline.
 - plotting a mesh's bathymetry with a non-zero datum using cmocean.
 - cell-averaging interpolation method in msh.interp fixed for unequal lon-lat DEM grid spacings
 
 ## Added
 - Mesh patch smoother
-- Ability to remesh abritary patches of elements within the domain while respecting user-defined mesh sizes and the patches boundaries. 
+- Ability to remesh abritary patches of elements within the domain while respecting user-defined mesh sizes and the patches boundaries.
 - Ability to use the TPXO9 Atlas for the tidal bcs and sponge (inside tidal_data_to_ob.m and Calc_Sponge.m) by using '**' wildcards in place of the constituent name within the tidal atlas filename (the atlas has an individual file for each constituent).
 - Introducing 'auto_outer' option for the make_bc msh method which populates the bc for the outermost mesh boundary polygon (ignores islands)
 - Changelog to README
@@ -155,14 +159,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - 'invert' option in the msh.interp method to turn off the DEM value inversion typically performed
 
 ## Changed
-- for the make_bc msh method 'auto'/'auto_outer' options, allowing for the 'depth' method of classification to use the interpolated depths on the mesh if gdat is empty. 
+- for the make_bc msh method 'auto'/'auto_outer' options, allowing for the 'depth' method of classification to use the interpolated depths on the mesh if gdat is empty.
 - improving help for make_bc msh method, Make_f15.m and Calc_Sponge.m
 - renamed "ExtractSubDomain.m" to "extract_subdomain.m"
 - improving "extract_subdomain.m" help and facilitating NaN-delimited polygons
 - ability to return boundary as a cell in "getBoundaryOfMesh" msh method
 - "Example_1_NZ.m" includes example of plotting bcs of a msh subset
-- using "mapMeshproperties" method in "fixmeshandcarry" 
+- using "mapMeshproperties" method in "fixmeshandcarry"
 - using "fixmeshandcarry" in the "cat" msh method
 - improving warning and error messages for the "interp" msh method
 - adding geofactor into "writefort15" for the GAHM vortex model
-

--- a/utilities/Make_f20.m
+++ b/utilities/Make_f20.m
@@ -1,8 +1,8 @@
-function obj = Make_f20(obj,File_Prefix,File_Suffixes,bathyfile,ETIMINC)
-% obj = Make_f20(obj,File_Prefix,File_Suffixes,bathyfile,ETIMINC)
+function obj = Make_f20(obj,filenames,bathyfile,ETIMINC)
+% obj = Make_f20(obj,filenames,bathyfile,ETIMINC)
 % Input a msh class object get the values of the elevations and normal
-% fluxes for times between ts and te based on the File_Suffixes of the 
-% input files (location is File_Prefix). Bathyfile is the file of 
+% fluxes for times between ts and te based on the input files
+% specified by a cell array of filenames. Bathyfile is the file of 
 % bathymetric values used to calculate fluxes from the velocities
 %
 %  Author:      William Pringle                                 
@@ -34,10 +34,10 @@ end
 % Do projection
 [b_x,b_y] = m_ll2xy(b_lon,b_lat);   
 
-BZ = zeros(length(b_x),length(File_Suffixes));
-BF = zeros(length(b_x),length(File_Suffixes));
-for t = 1:length(File_Suffixes)
-    filename = strcat(File_Prefix,File_Suffixes(t),".nc");
+BZ = zeros(length(b_x),length(filenames));
+BF = zeros(length(b_x),length(filenames));
+for t = 1:length(filenames)
+    filename = filenames{t};
     %% Read the grid and density data 
     if t == 1
         % read lon, lat and standard depths
@@ -111,9 +111,8 @@ for t = 1:length(File_Suffixes)
 end
 
 %% Make into f20 struct
-filename1 = strcat(File_Prefix,File_Suffixes(1),".nc");
-filename2 = strcat(File_Prefix,File_Suffixes(end),".nc");
-[~,n1] = fileparts(char(filename1)); [~,n2] = fileparts(char(filename2));
+n1 = filenames{1};
+n2 = filenames{end};
 obj.f20.DataTitle = [n1 ' -> ' n2];
 obj.f20.ETIMINC = ETIMINC;
 obj.f20.NumOfNodes = size(BZ,1);


### PR DESCRIPTION
* Update msh.m

* Modifications to plot
- adding a plotter subfuction used by a few of the case selects to streamline things
- changing numticks option to 'colormap' to specify the colormap intervals
- removing the mannings, cfval, ifric, tau0 fort13 options to use the arbitrary f13 attribute plotter instead
- adding help for transect and sponge options

* changing Make_f20.m input to just use a cell array of filenames instead of directory filename parts (one can add the directory of the files to path if necessary)

* make all name/value pairs

* msh.plot kwarg bou -> subset

* update changelog

* refining the help and adding 'proj' 'none' kwarg option to plot without m_map projection

* modifying the plotting calls to match new 'plot' kwarg format

Co-authored-by: William Pringle <wpringle@anl.gov>